### PR TITLE
Fix cadvisor and node exporter configs

### DIFF
--- a/ansible/roles/cadvisor/files/cadvisor.service
+++ b/ansible/roles/cadvisor/files/cadvisor.service
@@ -3,8 +3,7 @@ Description=Cadvisor Daemon
 
 [Service]
 Restart=always
-User=nobody
-ExecStart=/usr/local/bin/cadvisor --port 9180
+ExecStart=/usr/local/bin/cadvisor --docker_only --port 9180
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/node-exporter/files/prometheus-node-exporter.service
+++ b/ansible/roles/node-exporter/files/prometheus-node-exporter.service
@@ -4,8 +4,7 @@ Description=Prometheus exporter for machine metrics
 [Service]
 Restart=always
 User=nobody
-ExecStart=/usr/local/bin/node_exporter \
-    --collector.filesystem.ignored-fs-types="^(sys|proc|auto|au|ns)fs$"
+ExecStart=/usr/local/bin/node_exporter
 ExecReload=/bin/kill -HUP $MAINPID
 TimeoutStopSec=20s
 SendSIGKILL=no


### PR DESCRIPTION
The 'docker_only' scope in cAdvisor is well-suited, ensuring a reduced footprint for the cAdvisor service.

The node_exporter exludes various mount points and file system types by default. You can review the exclusions at https://github.com/prometheus/node_exporter/blob/v1.7.0/collector/filesystem_linux.go#L38

Related issue: https://github.com/SovereignCloudStack/issues/issues/398