### PR TITLE
Enable Zuul Scheduler and Zookeeper metrics

### DIFF
--- a/ansible/exporters.yml
+++ b/ansible/exporters.yml
@@ -4,5 +4,8 @@
   become: true
   roles:
     - node-exporter
-    - statsd-exporter
     - cadvisor
+    ## Note (@mfeder): The decision is not to use the statsd->prometheus mapping for Zuul metrics.
+    ## See https://input.scs.community/2023-scs-team-ops#How-to-get-Zuul-Statsd-Metrics-into-the-Observer-Prometheus-Cluster-matofeder-o-otte
+    ## Therefore, the statsd-exporter is excluded.
+    # - statsd-exporter

--- a/ansible/group_vars/zuul/zuul-config.yaml
+++ b/ansible/group_vars/zuul/zuul-config.yaml
@@ -8,6 +8,8 @@ zuul_zuul_tag: "9.2.0"
 zuul_nodepool_tag: "9.0.0"
 zuul_zookeeper_tag: "3.7.2"
 
+zuul_statsd_host: "213.131.230.154"
+
 zuul_webserver_fqdn: "{{ prod_zuul_webserver_fqdn if ('zuul.dev' not in inventory_hostname) else dev_zuul_webserver_fqdn }}"
 zuul_logserver_fqdn: "{{ prod_zuul_logserver_fqdn if ('zuul.dev' not in inventory_hostname) else dev_zuul_logserver_fqdn }}"
 dev_zuul_webserver_fqdn: "zuul-dev.scs.community"

--- a/ansible/zuul.yaml
+++ b/ansible/zuul.yaml
@@ -183,6 +183,9 @@
       vars:
         zuul_auth_secret: "{{ vault_zuul_auth_secret }}"
 
+        zuul_zookeeper_metrics: true
+        zuul_metrics_statsd_host: "{{ zuul_statsd_host }}"
+
         zuul_database:
           user_name: "{{ vault_db_user_name }}"
           user_pass: "{{ vault_db_user_pass }}"


### PR DESCRIPTION
This PR enables Zuul scheduler (statsd) and Zookeeper (build-in prom. exporter) metrics.

This PR should be merged after upstream PRs:
- https://github.com/osism/ansible-collection-services/pull/1277
- https://github.com/osism/ansible-collection-services/pull/1276

related issue: https://github.com/SovereignCloudStack/issues/issues/398 