### PR TITLE
Add Security pipeline repo to repos observed by zuul

### DIFF
--- a/ansible/group_vars/zuul/zuul-config.yaml
+++ b/ansible/group_vars/zuul/zuul-config.yaml
@@ -43,7 +43,8 @@ untrusted_projects:
 - SovereignCloudStack/infrastructure
 - SovereignCloudStack/issues
 - SovereignCloudStack/k8s-cassandra
-- SovereignCloudStack/k8s-cluster-api-provider
+- SovereignCloudStack/k8s-cluster-api-provider:
+    exclude-unprotected-branches: true
 - SovereignCloudStack/k8s-cortex
 - SovereignCloudStack/k8s-gatekeeper
 - SovereignCloudStack/k8s-grafana
@@ -61,11 +62,15 @@ untrusted_projects:
 - SovereignCloudStack/poc-gardener
 - SovereignCloudStack/poc-kubermatic
 - SovereignCloudStack/poc-rancher
+- SovereignCloudStack/security-infra-scan-pipeline:
+    exclude-unprotected-branches: true
 - SovereignCloudStack/testbed-gx-iam
 - SovereignCloudStack/testbed-gx-k8s
 - SovereignCloudStack/testbed-gx-scs
 - SovereignCloudStack/website
 - SovereignCloudStack/zuul_deployment
 - SovereignCloudStack/status-page-api
-- SovereignCloudStack/standards
+- SovereignCloudStack/standards:
+    exclude-unprotected-branches: true
 - SovereignCloudStack/container-images
+- SovereignCloudStack/zuul-mqtt-matrix-bridge


### PR DESCRIPTION
This PR updates the list of zuul managed repos to the current state, also including the new Repo for the Infra Security Pipeline definitions